### PR TITLE
add UNIQUE constrainst to github_id db schema field

### DIFF
--- a/src/model/database/db_build.sql
+++ b/src/model/database/db_build.sql
@@ -14,7 +14,7 @@ CREATE TABLE tech_stack (
 
 CREATE TABLE members (
   id SERIAL PRIMARY KEY,
-  github_id INTEGER NOT NULL,
+  github_id INTEGER UNIQUE NOT NULL,
   full_name VARCHAR(255),
   github_handle VARCHAR(255) NOT NULL,
   github_avatar_url VARCHAR(4000),

--- a/src/model/database/db_build_test.sql
+++ b/src/model/database/db_build_test.sql
@@ -14,7 +14,7 @@ CREATE TABLE tech_stack (
 
 CREATE TABLE members (
   id SERIAL PRIMARY KEY,
-  github_id INTEGER NOT NULL,
+  github_id INTEGER UNIQUE NOT NULL,
   full_name VARCHAR(255),
   github_handle VARCHAR(255) NOT NULL,
   github_avatar_url VARCHAR(4000),


### PR DESCRIPTION
closes #118 

This is failing Travis because of the test for the github API call function getGitHubRepoLanguages.  Separate issue #142 raised.  Travis should pass once this issue is closed. 