### PR TITLE
modularise queries and subqueries

### DIFF
--- a/src/model/queries/addFacCohortReturnID.js
+++ b/src/model/queries/addFacCohortReturnID.js
@@ -1,8 +1,0 @@
-const dbConnection = require('../database/db_connection');
-
-const addFacCohortReturnID = cohortName => dbConnection.query(
-  'INSERT INTO fac_cohort (cohort) VALUES ($1) RETURNING id',
-  [cohortName],
-).then(res => res[0]);
-
-module.exports = addFacCohortReturnID;

--- a/src/model/queries/getAllFacCohorts.js
+++ b/src/model/queries/getAllFacCohorts.js
@@ -1,5 +1,0 @@
-const dbConnection = require('../database/db_connection');
-
-const getAllFacCohorts = () => dbConnection.query('SELECT * FROM fac_cohort');
-
-module.exports = getAllFacCohorts;

--- a/src/model/queries/getAllMemberData.js
+++ b/src/model/queries/getAllMemberData.js
@@ -1,4 +1,4 @@
-const dbConnection = require('../database/db_connection.js');
+const db = require('../database/db_connection.js');
 
 const allMembersQuery =
   `SELECT mem.id, mem.github_id, mem.full_name, mem.github_handle, github_avatar_url, cohort.cohort AS fac_cohort, 
@@ -13,7 +13,7 @@ LEFT JOIN fac_cohort cohort
 ON mem.fac_cohort_id = cohort.id`;
 
 const getAllMemberData = () =>
-  dbConnection
+  db
     .query(allMembersQuery);
 
 module.exports = getAllMemberData;

--- a/src/model/queries/getFacCohortID.js
+++ b/src/model/queries/getFacCohortID.js
@@ -1,6 +1,0 @@
-const dbConnection = require('../database/db_connection');
-
-const getFacCohortID = cohortName => dbConnection.query('SELECT id FROM fac_cohort WHERE cohort = $1', [cohortName])
-  .then(res => res[0]);
-
-module.exports = getFacCohortID;

--- a/src/model/queries/getMemberData.js
+++ b/src/model/queries/getMemberData.js
@@ -1,7 +1,7 @@
-const dbConnection = require('../database/db_connection.js');
+const db = require('../database/db_connection.js');
 
 const getMemberData = githubID =>
-  dbConnection
+  db
     .query(`SELECT github_id, full_name, github_handle, github_avatar_url, fac_campus, fac_cohort.cohort AS fac_cohort, linkedin_url, twitter_handle, member_type, job_view_pref, job_search_status, years_experience, github_cv_url, cv_url 
     FROM members
     LEFT JOIN fac_cohort 

--- a/src/model/queries/index.js
+++ b/src/model/queries/index.js
@@ -1,12 +1,10 @@
 /* eslint global-require: off */
 module.exports = {
   getAllMemberData: require('./getAllMemberData'),
-  postMemberInfo: require('./postMemberInfo'),
   getMemberData: require('./getMemberData'),
-  getAllFacCohorts: require('./getAllFacCohorts'),
-  addFacCohortReturnID: require('./addFacCohortReturnID'),
-  getFacCohortID: require('./getFacCohortID'),
-  updateMemberDetails: require('./updateMemberDetails'),
+  postMemberInfo: require('./postMemberInfo'),
+  processMemberTechStack: require('./processMemberTechStack'),
   saveProfileData: require('./saveProfileData'),
   saveJobDetails: require('./saveJobDetails'),
+  updateMemberDetails: require('./updateMemberDetails'),
 };

--- a/src/model/queries/processMemberTechStack.js
+++ b/src/model/queries/processMemberTechStack.js
@@ -1,31 +1,30 @@
 const {
-  getAllTechStack,
-  addTechStack,
+  getAllTechFromTechStackTable,
+  addNewTechIntoTechStackTable,
   addMemberTechStack,
   deleteMemberTechStack,
-} = require('./queryDb_TechStackTables');
+} = require('./subqueries/queryDbTechStackTables');
 
-const removeArrayDuplicates = require('../../lib/removeArrayDuplicates')
-const lowerCaseArray = require('../../lib/lowerCaseArray')
+const removeArrayDuplicates = require('../../lib/removeArrayDuplicates');
+const lowerCaseArray = require('../../lib/lowerCaseArray');
 
 
 // addUniqueTech function = Takes is as parameter: Array of strings of tech stack (either from initial API on signup or from profile form submission) - this array can include dupes.
 // In the process, checks if any tech strings are NOT in the DB tech_stack table and adds them.
 
-const addUniqueTech = (techStackArray) =>
-  getAllTechStack()
+const addUniqueTech = techStackArray =>
+  getAllTechFromTechStackTable()
     .then((allTechStack) => {
-
       const lowerCaseAllTechStack = lowerCaseArray(allTechStack);
 
       return removeArrayDuplicates(techStackArray).reduce((acc, curr) => {
         if (!lowerCaseAllTechStack.includes(curr.toLowerCase())) {
-          acc.push(curr)
+          acc.push(curr);
         }
-        return acc
-      }, [])
+        return acc;
+      }, []);
     })
-    .then((res) => Promise.all(res.map((tech) => addTechStack(tech))))
+    .then(res => Promise.all(res.map(tech => addNewTechIntoTechStackTable(tech))));
 
 // processMemberTechStack function = Takes is as parameter: Array of strings of tech stack (either from initial API on signup or from profile form submission) - this array can include dupes.
 // Uses addUniqueTech to check if any tech strings are NOT in the DB tech_stack table and adds them.
@@ -34,17 +33,13 @@ const addUniqueTech = (techStackArray) =>
 const processMemberTechStack = (github_id, techStackArray) =>
   addUniqueTech(techStackArray)
     .then(() => deleteMemberTechStack(github_id))
-    .then(() => {
-      return removeArrayDuplicates(techStackArray).reduce((acc, curr, i) => {
-        acc.push({
-          techName: curr,
-          order_num: i,
-        })
-        return acc
-      }, [])
-    })
-    .then((res) => Promise.all(
-      res.map((tech) => addMemberTechStack(github_id, tech.techName, tech.order_num))
-    ))
+    .then(() => removeArrayDuplicates(techStackArray).reduce((acc, curr, i) => {
+      acc.push({
+        techName: curr,
+        order_num: i,
+      });
+      return acc;
+    }, []))
+    .then(res => Promise.all(res.map(tech => addMemberTechStack(github_id, tech.techName, tech.order_num))));
 
 module.exports = { addUniqueTech, processMemberTechStack };

--- a/src/model/queries/saveProfileData.js
+++ b/src/model/queries/saveProfileData.js
@@ -1,7 +1,10 @@
-const addFacCohortReturnID = require('./addFacCohortReturnID');
-const getFacCohortID = require('./getFacCohortID');
+const {
+  addFacCohortReturnID,
+  getFacCohortID,
+} = require('./subqueries/queryDbFacCohortTable');
 const updateMemberDetails = require('./updateMemberDetails');
 const makeFacCohortName = require('../../lib/makeFacCohortName');
+
 
 const saveProfileData = (dataObj, githubID) => {
   const objClone = JSON.parse(JSON.stringify(dataObj));

--- a/src/model/queries/subqueries/queryDbFacCohortTable.js
+++ b/src/model/queries/subqueries/queryDbFacCohortTable.js
@@ -1,0 +1,17 @@
+const db = require('../../database/db_connection');
+
+const getAllFacCohorts = () => db.query('SELECT * FROM fac_cohort');
+
+const getFacCohortID = cohortName => db.query('SELECT id FROM fac_cohort WHERE cohort = $1', [cohortName])
+  .then(res => res[0]);
+
+const addFacCohortReturnID = cohortName => db.query(
+  'INSERT INTO fac_cohort (cohort) VALUES ($1) RETURNING id',
+  [cohortName],
+).then(res => res[0]);
+
+module.exports = {
+  getAllFacCohorts,
+  getFacCohortID,
+  addFacCohortReturnID,
+};

--- a/src/model/queries/subqueries/queryDbTechStackTables.js
+++ b/src/model/queries/subqueries/queryDbTechStackTables.js
@@ -1,4 +1,4 @@
-const db = require('../database/db_connection');
+const db = require('../../database/db_connection');
 
 const addMemberTechStack = (github_id, techName, orderNum) => db.query(
   `INSERT INTO member_tech_stack VALUES
@@ -7,17 +7,17 @@ const addMemberTechStack = (github_id, techName, orderNum) => db.query(
   [github_id, techName, orderNum],
 );
 
-const getTechStackID = techName => db.query(
+const getTechIDFromTechStackTable = techName => db.query(
   'SELECT id FROM tech_stack WHERE LOWER(tech) = LOWER($1)',
   [techName],
 ).then(res => res[0]);
 
-const getAllTechStack = () => db.query('SELECT * FROM tech_stack').then(res => res.reduce((acc, curr) => {
+const getAllTechFromTechStackTable = () => db.query('SELECT * FROM tech_stack').then(res => res.reduce((acc, curr) => {
   acc.push(curr.tech);
   return acc;
 }, []));
 
-const addTechStack = techName => db.query(
+const addNewTechIntoTechStackTable = techName => db.query(
   'INSERT INTO tech_stack (tech) VALUES ($1)',
   [techName],
 );
@@ -59,9 +59,9 @@ const updateTechOrderNum = (github_id, techName, order_num) => db.query(
 
 module.exports = {
   addMemberTechStack,
-  getTechStackID,
-  getAllTechStack,
-  addTechStack,
+  getTechIDFromTechStackTable,
+  getAllTechFromTechStackTable,
+  addNewTechIntoTechStackTable,
   deleteMemberTech,
   getMemberTechStack,
   updateTechOrderNum,

--- a/src/model/queries/updateMemberDetails.js
+++ b/src/model/queries/updateMemberDetails.js
@@ -1,6 +1,6 @@
-const dbConnection = require('../database/db_connection');
+const db = require('../database/db_connection');
 
-const updateMemberDetails = (formDataObj, facCohortID, githubID) => dbConnection.query(`
+const updateMemberDetails = (formDataObj, facCohortID, githubID) => db.query(`
     UPDATE members
     SET full_name = $/full_name/,
         github_handle = $/github_handle/,

--- a/src/test/db.test.js
+++ b/src/test/db.test.js
@@ -5,9 +5,6 @@ const dbConnection = require('../model/database/db_connection');
 const {
   postMemberInfo,
   getMemberData,
-  getAllFacCohorts,
-  addFacCohortReturnID,
-  getFacCohortID,
   updateMemberDetails,
   getAllMemberData,
   saveProfileData,
@@ -16,14 +13,20 @@ const {
 
 const {
   addMemberTechStack,
-  getTechStackID,
-  getAllTechStack,
-  addTechStack,
+  getTechIDFromTechStackTable,
+  getAllTechFromTechStackTable,
+  addNewTechIntoTechStackTable,
   deleteMemberTech,
   getMemberTechStack,
   updateTechOrderNum,
   deleteMemberTechStack,
-} = require('../model/queries/queryDb_TechStackTables');
+} = require('../model/queries/subqueries/queryDbTechStackTables');
+
+const {
+  addFacCohortReturnID,
+  getAllFacCohorts,
+  getFacCohortID,
+} = require('../model/queries/subqueries/queryDbFacCohortTable');
 
 const {
   processMemberTechStack,
@@ -363,11 +366,11 @@ test('Test saveJobDetails saves job details', (t) => {
   });
 });
 
-// getAllTechStack
+// getAllTechFromTechStackTable
 
-test('Test getAllTechStack gets all stack', (t) => {
+test('Test getAllTechFromTechStackTable gets all stack', (t) => {
   runDbBuild().then(() => {
-    getAllTechStack().then((res) => {
+    getAllTechFromTechStackTable().then((res) => {
       const expected = ['JavaScript', 'Node.js'];
       t.pass(Array.isArray(res), 'response is an array');
       t.equal(expected.length, res.length, 'response contains appropriate number of entries');
@@ -375,23 +378,23 @@ test('Test getAllTechStack gets all stack', (t) => {
       t.end();
     }).catch((err) => {
       console.log(err.message);
-      t.error(err, 'getAllTechStack test error');
+      t.error(err, 'getAllTechFromTechStackTable test error');
       t.end();
     });
   });
 });
 
-// addTechStack
+// addNewTechIntoTechStackTable
 
-test('Test addTechStack saves a new techstack', (t) => {
+test('Test addNewTechIntoTechStackTable saves a new techstack', (t) => {
   runDbBuild().then(() => {
     let oldStack;
-    getAllTechStack()
+    getAllTechFromTechStackTable()
       .then((res) => {
         oldTechStack = JSON.parse(JSON.stringify(res));
       })
-      .then(() => addTechStack('PostgreSQL'))
-      .then(() => getAllTechStack())
+      .then(() => addNewTechIntoTechStackTable('PostgreSQL'))
+      .then(() => getAllTechFromTechStackTable())
       .then((res) => {
         const expected = ['JavaScript', 'Node.js', 'PostgreSQL'];
         t.pass(Array.isArray(res), 'response is an array');
@@ -401,17 +404,17 @@ test('Test addTechStack saves a new techstack', (t) => {
       })
       .catch((err) => {
         console.log(err.message);
-        t.error(err, 'addTechStack test error');
+        t.error(err, 'addNewTechIntoTechStackTable test error');
         t.end();
       });
   });
 });
 
-// getTechStackID
+// getTechIDFromTechStackTable
 
-test('Test getTechStackID returns the correct ID', (t) => {
+test('Test getTechIDFromTechStackTable returns the correct ID', (t) => {
   runDbBuild().then(() => {
-    getTechStackID('JavaScript')
+    getTechIDFromTechStackTable('JavaScript')
       .then((res) => {
         t.equals(typeof res, 'object', 'response is an object');
         t.equals(1, res.id, 'has returned the correct ID');
@@ -419,21 +422,21 @@ test('Test getTechStackID returns the correct ID', (t) => {
         t.end();
       }).catch((err) => {
         console.log(err.message);
-        t.error(err, 'getTechStackID test error');
+        t.error(err, 'getTechIDFromTechStackTable test error');
         t.end();
       });
   });
 });
 
-test('Test getTechStackID returns undefined if not in tech_stack table', (t) => {
+test('Test getTechIDFromTechStackTable returns undefined if not in tech_stack table', (t) => {
   runDbBuild().then(() => {
-    getTechStackID('PostgreSQL')
+    getTechIDFromTechStackTable('PostgreSQL')
       .then((res) => {
         if (!res) t.pass('has returned undefined');
         t.end();
       }).catch((err) => {
         console.log(err.message);
-        t.error(err, 'getTechStackID test error');
+        t.error(err, 'getTechIDFromTechStackTable test error');
         t.end();
       });
   });
@@ -551,10 +554,10 @@ test('Test addUniqueTech to ensure added unique tech, and no duplicate additions
   runDbBuild().then(() => {
     let oldTechStackList;
     const formData = ['javascript', 'Node.js', 'PostgreSQL', 'HTML', 'html'];
-    getAllTechStack()
+    getAllTechFromTechStackTable()
       .then(res => oldTechStackList = JSON.parse(JSON.stringify(res)))
       .then(() => addUniqueTech(formData))
-      .then(() => getAllTechStack())
+      .then(() => getAllTechFromTechStackTable())
       .then((res) => {
         const expected = ['JavaScript', 'Node.js', 'PostgreSQL', 'HTML'];
         t.equal(oldTechStackList.length + 2, res.length, 'added two new items to tech stack');


### PR DESCRIPTION
Tidied up the query folder - relates #59 refactor
* only queries used by controllers are in the query/index.js file
* subqueries required only by other queries are in a subquery folder
* removed _ from file names
* renamed some of the techstack subqueries to clarify what is adding Tech to the Tech_Stack table vs what is adding stack info to the Member_Tech_Stack Table. 

